### PR TITLE
chore: Update codecov-action hash to 39a2af19d997be74586469d4062e173ecae614f6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Codecov
         if: github.event_name != 'merge_group'
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        uses: codecov/codecov-action@39a2af19d997be74586469d4062e173ecae614f6 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Updates codecov-action hash from 18283e04ce6e62d37312384ff67231eb8fd56d24 to 39a2af19d997be74586469d4062e173ecae614f6

This change aligns the codecov-action version with the renovate repository.